### PR TITLE
For --enable-m32 (standalone), also make lib/dmtcp/32/bin/*

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -99,11 +99,7 @@ display-config:
 	   fi
 
 dmtcp:
-ifeq ($(M32),1)
-	cd src && $(MAKE) libs
-else
 	cd src && $(MAKE)
-endif
 
 plugin: dmtcp
 	cd plugin && $(MAKE)


### PR DESCRIPTION
This is the beginning of a fix to allow --enable-m32 to once again create a standalone M32 implementation.  After this, the user can do:  `(mkdir bin; cd bin; ln -s ../lib/dmtcp/32/bin/* ./)`
and `(mkdir lib; cd lib; ln -s ../lib/dmtcp/32/lib/dmtcp/* ./)` to create a working DMTCP with --enable-m32.  (This would also require reverting the commit involving vvar, or at least ressurecting the "duct tape code".)
We should discuss what to do after this.  One possibility is to create a new:  `./configure --enable-multi-arch`
and have that follow the standard recipe (make with M32 and without).  It will be simpler to resolve that decision by phone.
